### PR TITLE
Refactor run loop into reusable modules

### DIFF
--- a/agent_utils.py
+++ b/agent_utils.py
@@ -1,0 +1,55 @@
+import json
+import subprocess
+from pathlib import Path
+from datetime import datetime
+
+ENTERPRISE_ROOT = Path(__file__).resolve().parent
+MEMORY_DIR = ENTERPRISE_ROOT / "memory"
+PROMPT_DIR = ENTERPRISE_ROOT / "prompts"
+LOG_DIR = ENTERPRISE_ROOT / "logs"
+OLLAMA_MODEL = "qwen2.5:14b"
+
+LOG_DIR.mkdir(exist_ok=True)
+
+def load_goal() -> str:
+    """Return the current goal from ``memory/goals.json``."""
+    with open(MEMORY_DIR / "goals.json") as f:
+        return json.load(f)["current_goal"]
+
+def load_prompt(agent_name: str) -> str:
+    """Return the prompt text for a given agent."""
+    with open(PROMPT_DIR / f"{agent_name}_prompt.txt") as f:
+        return f.read()
+
+def call_ollama(prompt: str) -> str:
+    """Execute an Ollama model with the provided prompt."""
+    result = subprocess.run(
+        ["ollama", "run", OLLAMA_MODEL],
+        input=prompt.encode("utf-8"),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout.decode("utf-8")
+
+def log_agent_output(agent_name: str, context: str, output: str) -> Path:
+    """Write agent interaction details to a markdown log file."""
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    filename = LOG_DIR / f"{agent_name}_{timestamp}.md"
+    with open(filename, "w") as f:
+        f.write(f"# Agent: {agent_name}\n")
+        f.write(f"## Timestamp: {timestamp}\n\n")
+        f.write("### Context\n")
+        f.write("```\n" + context.strip() + "\n```\n\n")
+        f.write("### Output\n")
+        f.write("```\n" + output.strip() + "\n```\n")
+    return filename
+
+def run_agent(agent_name: str, context: str) -> str:
+    """Run an agent with the provided context and return its response."""
+    print(f"\n>>> Running {agent_name}...")
+    prompt = load_prompt(agent_name)
+    full_prompt = f"{prompt}\n\nCONTEXT:\n{context.strip()}"
+    response = call_ollama(full_prompt)
+    print(f"\n--- {agent_name} Response ---\n{response.strip()}\n")
+    log_agent_output(agent_name, context, response)
+    return response.strip()

--- a/run_enterprise.py
+++ b/run_enterprise.py
@@ -1,63 +1,18 @@
-import json
-import subprocess
-from pathlib import Path
-from datetime import datetime
+from agent_utils import load_goal, run_agent
 
-ENTERPRISE_ROOT = Path(__file__).parent
-MEMORY_DIR = ENTERPRISE_ROOT / "memory"
-PROMPT_DIR = ENTERPRISE_ROOT / "prompts"
-LOG_DIR = ENTERPRISE_ROOT / "logs"
-OLLAMA_MODEL = "qwen2.5:14b"
+AGENT_SEQUENCE = ["planner", "executor", "loopmind", "challenger"]
 
-LOG_DIR.mkdir(exist_ok=True)
 
-def load_goal():
-    with open(MEMORY_DIR / "goals.json") as f:
-        return json.load(f)["current_goal"]
+def run_cycle(sequence=AGENT_SEQUENCE) -> None:
+    """Execute one complete agent cycle using the given agent order."""
+    context = load_goal()
+    print(f"=== Current Goal: {context} ===")
 
-def call_ollama(prompt: str) -> str:
-    result = subprocess.run(
-        ["ollama", "run", OLLAMA_MODEL],
-        input=prompt.encode("utf-8"),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    return result.stdout.decode("utf-8")
-
-def load_prompt(agent_name: str) -> str:
-    with open(PROMPT_DIR / f"{agent_name}_prompt.txt") as f:
-        return f.read()
-
-def log_agent_output(agent_name: str, context: str, output: str):
-    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    filename = LOG_DIR / f"{agent_name}_{timestamp}.md"
-    with open(filename, "w") as f:
-        f.write(f"# Agent: {agent_name}\n")
-        f.write(f"## Timestamp: {timestamp}\n\n")
-        f.write("### Context\n")
-        f.write("```\n" + context.strip() + "\n```\n\n")
-        f.write("### Output\n")
-        f.write("```\n" + output.strip() + "\n```\n")
-
-def run_agent(agent_name: str, context: str) -> str:
-    print(f"\n>>> Running {agent_name}...")
-    prompt = load_prompt(agent_name)
-    full_prompt = f"{prompt}\n\nCONTEXT:\n{context.strip()}"
-    response = call_ollama(full_prompt)
-    print(f"\n--- {agent_name} Response ---\n{response.strip()}\n")
-    log_agent_output(agent_name, context, response)
-    return response.strip()
-
-def run_loop():
-    goal = load_goal()
-    print(f"=== Current Goal: {goal} ===")
-
-    tasks = run_agent("planner", goal)
-    execution_summary = run_agent("executor", tasks)
-    reflection = run_agent("loopmind", execution_summary)
-    run_agent("challenger", reflection)
+    for agent in sequence:
+        context = run_agent(agent, context)
 
     print("\n=== CYCLE COMPLETE ===")
 
+
 if __name__ == "__main__":
-    run_loop()
+    run_cycle()


### PR DESCRIPTION
## Summary
- split utility functions into new `agent_utils.py`
- simplify `run_enterprise.py` to a concise cycle runner using `agent_utils`

## Testing
- `python -m py_compile run_enterprise.py agent_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68522b5cc4ac832a85acfe5147083e72