### PR TITLE
Enhance planner context with recent history

### DIFF
--- a/prompts/planner_prompt.txt
+++ b/prompts/planner_prompt.txt
@@ -13,3 +13,8 @@ Your tasks must be:
 - Able to be executed, simulated, or researched by another agent
 
 Respond only with the formatted list of tasks and brief rationale.
+
+You may reference prior tasks and outcomes to improve future planning.
+PRIOR_TASKS and OUTCOMES (last 3 entries):
+
+{{INSERT_RECENT_TASKS_AND_OUTCOMES_HERE}}


### PR DESCRIPTION
## Summary
- provide planner with previous task and outcome summary in prompt
- expose `get_recent_task_and_outcome_summaries` helper
- inject latest summaries when launching the planner

## Testing
- `python3 -m py_compile run_enterprise.py`

------
https://chatgpt.com/codex/tasks/task_e_684a8dbf8928832ab2477ad5732d6a04