### PR TITLE
Unify runner modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,13 +39,13 @@ This project orchestrates several autonomous agents to evolve the **Autonomous W
 
 ## Adding New Agents
 1. Create a new prompt file in `prompts/` named `<agent>_prompt.txt` describing the role, required context, and output format.
-2. Extend `run_enterprise.py` to call the new agent in the desired order using `run_agent("<agent>", context)`.
+2. Extend `enterprise_runner.py` (the `EnterpriseRunner` class) to call the new agent in the desired order using `run_agent("<agent>", context)`.
 3. Document the agent in this file under **Current Agents** with its role and output expectations.
 4. Commit the prompt and code changes along with an update to `changelog.md`.
 5. Ensure the agent respects `governance.md` and logs its output under `logs/`.
 
 ## Coding & Prompt Conventions
-* Keep agent code in Python and follow the existing pattern in `run_enterprise.py`.
+* Keep agent code in Python and follow the existing pattern in `enterprise_runner.py`.
 * Prompts should explicitly reference any docs the agent must read (e.g., `manifesto.md`, `system_lifecycle.md`).
 * Agents should respond in concise markdown where possible and avoid unnecessary verbosity.
 * Every agent invocation is logged via `log_agent_output()` for traceability.

--- a/enterprise_runner.py
+++ b/enterprise_runner.py
@@ -3,28 +3,43 @@ from datetime import datetime
 import json
 import subprocess
 
+
+def _noop(*args, **kwargs):
+    """Utility no-op for disabled debug prints."""
+    pass
+
 class EnterpriseRunner:
     """Handles the multi-agent orchestration loop."""
 
-    def __init__(self, model: str = "qwen2.5:14b"):
+    def __init__(self, model: str = "qwen2.5:14b", *, debug: bool = False, quiet: bool = False):
         self.enterprise_root = Path(__file__).parent
         self.memory_dir = self.enterprise_root / "memory"
         self.prompt_dir = self.enterprise_root / "prompts"
         self.log_dir = self.enterprise_root / "logs"
         self.ollama_model = model
+        self.debug = debug
+        self.quiet = quiet
         self.log_dir.mkdir(exist_ok=True)
+
+        self._debug_print = print if self.debug else _noop
+
+    def _speak(self, msg: str):
+        if not self.quiet:
+            print(msg)
 
     def load_goal(self) -> str:
         with open(self.memory_dir / "goals.json") as f:
             return json.load(f)["current_goal"]
 
     def call_ollama(self, prompt: str) -> str:
+        self._debug_print(f"Calling Ollama with model {self.ollama_model}")
         result = subprocess.run(
             ["ollama", "run", self.ollama_model],
             input=prompt.encode("utf-8"),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
+        self._debug_print(result.stderr.decode("utf-8"))
         return result.stdout.decode("utf-8")
 
     def load_prompt(self, agent_name: str) -> str:
@@ -43,13 +58,19 @@ class EnterpriseRunner:
             f.write("```\n" + output.strip() + "\n```\n")
 
     def run_agent(self, agent_name: str, context: str) -> str:
-        print(f"\n>>> Running {agent_name}...")
+        self._speak(f"\n>>> Running {agent_name}...")
         prompt = self.load_prompt(agent_name)
+        self._debug_print(f"Prompt:\n{prompt}")
         full_prompt = f"{prompt}\n\nCONTEXT:\n{context.strip()}"
+        self._debug_print(f"Full prompt:\n{full_prompt}")
         response = self.call_ollama(full_prompt)
-        print(f"\n--- {agent_name} Response ---\n{response.strip()}\n")
-        self.log_agent_output(agent_name, context, response)
-        return response.strip()
+        cleaned = response.strip()
+        if not self.quiet:
+            print(f"\n--- {agent_name} Response ---\n{cleaned}\n")
+        else:
+            self._debug_print(f"{agent_name} Response:\n{cleaned}")
+        self.log_agent_output(agent_name, context, cleaned)
+        return cleaned
 
     def run_loop(self):
         goal = self.load_goal()

--- a/run_enterprise.py
+++ b/run_enterprise.py
@@ -1,152 +1,18 @@
-import json
-import subprocess
-from datetime import datetime
-from pathlib import Path
 import argparse
+import json
+from pathlib import Path
+
+from enterprise_runner import EnterpriseRunner
 
 ENTERPRISE_ROOT = Path(__file__).parent
-MEMORY_DIR = ENTERPRISE_ROOT / "memory"
-PROMPT_DIR = ENTERPRISE_ROOT / "prompts"
-LOG_DIR = ENTERPRISE_ROOT / "logs"
-CONFIG_PATH = MEMORY_DIR / "config.json"
-OLLAMA_MODEL = "qwen2.5:14b"
-
-DEBUG = False
-QUIET = False
-LOGBOOK_PATH = None
-AGENT_SEQUENCE = ["planner", "executor", "loopmind", "challenger"]
-
-LOG_DIR.mkdir(exist_ok=True)
-
-# ----------------------------------------
-# Utility + I/O Functions
-# ----------------------------------------
-
-
-def debug_print(msg: str):
-    if DEBUG:
-        print(msg)
-
-
-def speak(msg: str):
-    if not QUIET:
-        print(msg)
+CONFIG_PATH = ENTERPRISE_ROOT / "memory" / "config.json"
 
 
 def load_config() -> dict:
     if CONFIG_PATH.exists():
-        with open(CONFIG_PATH) as f:
+        with CONFIG_PATH.open() as f:
             return json.load(f)
     return {"debug": False, "quiet": False}
-
-
-def init_logbook() -> Path:
-    global LOGBOOK_PATH
-    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    LOGBOOK_PATH = LOG_DIR / f"logbook_{timestamp}.md"
-    with open(LOGBOOK_PATH, "w") as f:
-        f.write(f"# 📓 AWE Logbook - {timestamp}\n\n")
-    return LOGBOOK_PATH
-
-
-def log_agent_output(agent_name: str, context_label: str, context: str, output: str):
-    if LOGBOOK_PATH is None:
-        raise RuntimeError("Logbook not initialized")
-
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    with open(LOGBOOK_PATH, "a") as f:
-        f.write(f"## 🤖 Agent: {agent_name}\n")
-        f.write(f"**Timestamp:** {timestamp}\n\n")
-        f.write(f"### {context_label}\n{context.strip()}\n\n")
-        f.write(f"### 📣 Output\n{output.strip()}\n\n---\n\n")
-
-
-def append_task_log(entry: dict):
-    path = MEMORY_DIR / "task_log.json"
-    data = []
-    if path.exists():
-        with path.open() as f:
-            data = json.load(f)
-    data.append(entry)
-    with path.open("w") as f:
-        json.dump(data, f, indent=2)
-
-
-# ----------------------------------------
-# Core Execution Logic
-# ----------------------------------------
-
-
-def load_goal() -> str:
-    with open(MEMORY_DIR / "goals.json") as f:
-        return json.load(f)["current_goal"]
-
-
-def load_prompt(agent_name: str) -> str:
-    with open(PROMPT_DIR / f"{agent_name}_prompt.txt") as f:
-        return f.read()
-
-
-def call_ollama(prompt: str) -> str:
-    debug_print(f"Calling Ollama with model {OLLAMA_MODEL}")
-    result = subprocess.run(
-        ["ollama", "run", OLLAMA_MODEL],
-        input=prompt.encode("utf-8"),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    debug_print(result.stderr.decode("utf-8"))
-    return result.stdout.decode("utf-8")
-
-
-def run_agent(agent_name: str, context_label: str, context: str) -> str:
-    speak(f"\n>>> Running {agent_name}...")
-    prompt = load_prompt(agent_name)
-    debug_print(f"Prompt:\n{prompt}")
-    full_prompt = f"{prompt}\n\nCONTEXT:\n{context.strip()}"
-    debug_print(f"Full prompt:\n{full_prompt}")
-    response = call_ollama(full_prompt)
-    cleaned = response.strip()
-    if not QUIET:
-        print(f"\n--- {agent_name} Response ---\n{cleaned}\n")
-    else:
-        debug_print(f"{agent_name} Response:\n{cleaned}")
-    log_agent_output(agent_name, context_label, context, cleaned)
-    return cleaned
-
-
-# ----------------------------------------
-# Full Cycle Runner
-# ----------------------------------------
-
-
-def run_cycle() -> None:
-    init_logbook()
-    goal = load_goal()
-    print(f"=== Current Goal: {goal} ===")
-
-    tasks = run_agent("planner", "Goal", goal)
-    execution_summary = run_agent("executor", "Task List", tasks)
-    reflection = run_agent("loopmind", "Execution Summary", execution_summary)
-    challenge = run_agent("challenger", "Reflection", reflection)
-
-    append_task_log(
-        {
-            "timestamp": datetime.utcnow().isoformat(),
-            "goal": goal,
-            "tasks": tasks,
-            "execution": execution_summary,
-            "reflection": reflection,
-            "challenge": challenge,
-        }
-    )
-
-    print("\n=== CYCLE COMPLETE ===")
-
-
-# ----------------------------------------
-# CLI Entrypoint
-# ----------------------------------------
 
 
 def parse_args() -> argparse.Namespace:
@@ -159,6 +25,7 @@ def parse_args() -> argparse.Namespace:
 if __name__ == "__main__":
     args = parse_args()
     cfg = load_config()
-    DEBUG = args.debug or cfg.get("debug", False)
-    QUIET = args.quiet or cfg.get("quiet", False)
-    run_cycle()
+    debug = args.debug or cfg.get("debug", False)
+    quiet = args.quiet or cfg.get("quiet", False)
+    runner = EnterpriseRunner(debug=debug, quiet=quiet)
+    runner.run_loop()


### PR DESCRIPTION
## Summary
- refactor EnterpriseRunner with debug and quiet support
- simplify run_enterprise.py to use EnterpriseRunner
- update agent docs for new module name

## Testing
- `python -m py_compile enterprise_runner.py run_enterprise.py agent_utils.py`
- `python run_enterprise.py --help | head`

------
https://chatgpt.com/codex/tasks/task_e_6854a5d00f04832ab1013910ec01e4cf